### PR TITLE
Fix buffer overrun in md5_update().

### DIFF
--- a/md5.c
+++ b/md5.c
@@ -167,6 +167,7 @@ void md5_update(struct md5_context* ctx, const void* buffer, uint32_t buffer_siz
 
     if (buffer_size >= 64) {
         buffer = md5_transform(ctx, buffer, buffer_size & ~(unsigned long)0x3f);
+        buffer_size = buffer_size % 64;
     }
 
     memcpy(ctx->input, buffer, buffer_size);

--- a/tests.c
+++ b/tests.c
@@ -30,6 +30,15 @@ int run_tests() {
         md5("12345678901234567890123456789012345678901234567890123456789012345678901234567890"), \
         "57edf4a22be3c955ac49da2e2107b67a") ? passed++ : failed++;
 
+    char *str = "the quick brown fox jumped over the lazy dog.\n"
+        "the quick brown fox jumped over the lazy dog.\n"
+        "the quick brown fox jumped over the lazy dog.\n"
+        "the quick brown fox jumped over the lazy dog.\n"
+        "the quick brown fox jumped over the lazy dog.\n"
+        "the quick brown fox jumped over the lazy dog.\n";
+
+    run_test(str, md5(str), "590769b959d6d65ccb16c7fb0decc950") ? passed++ : failed++;
+
     printf("Tests Passed: %i\n", passed);
     printf("Tests Failed: %i\n", failed);
     return failed;


### PR DESCRIPTION
@galenguyer  I think there is a serious error in `md5_update()` that causes it to
overwrite the stack and segfault on any input > 130 byes.

Near the bottom of md5_update(), there is:

```
  168     if (buffer_size >= 64) {
  169         buffer = md5_transform(ctx, buffer, buffer_size & ~(unsigned long)0x3f);
  170     }
  171 
  172     memcpy(ctx->input, buffer, buffer_size);
```

Line 169 advances the `buffer` pointer by several multiples of 64, but
fails to advance `buffer_size` by the corresponding amount.  As a
result, in line 172, buffer_size is much too large and if the input is
long enough, the memcpy() trashes the stack and the program segfaults.

This can be seen by the addition to `test.c` in this PR.  Using the
extra test without the fix to md5.c results in:

```
$ ./tests -t
...
TEST PASSED: md5("12345678901234567890123456789012345678901234567890123456789012345678901234567890"): expected 57edf4a22be3c955ac49da2e2107b67a, got 57edf4a22be3c955ac49da2e2107b67a
Segmentation fault (core dumped)

(gdb) bt
#0  0x00000000004015f7 in md5 ()
#1  0x67617373656d0029 in ?? ()
#2  0x7473656769642065 in ?? ()
#3  0x656d222835646d00 in ?? ()
#4  0x6964206567617373 in ?? ()
#5  0x6100292274736567 in ?? ()
...
```

The fix is to update `buffer_size` along with the `buffer` pointer.

```
@@ -167,6 +167,7 @@ void md5_update(struct md5_context* ctx, const void* buffer, uint32_t buffer_siz
 
     if (buffer_size >= 64) {
         buffer = md5_transform(ctx, buffer, buffer_size & ~(unsigned long)0x3f);
+        buffer_size = buffer_size % 64;
     }
 
     memcpy(ctx->input, buffer, buffer_size);
```

I guess you never tested it on inputs > 130 bytes.

Btw, IMO there are cleaner ways of writing the tests.  If it were me,
I would write test.c as taking its input from a file name or stdin and
matching the output of md5sum.  That would make it easier to test the
code on an arbitrary input and compare the output with md5sum.

